### PR TITLE
findOneBy uses one single query

### DIFF
--- a/src/MongoDBRepository.php
+++ b/src/MongoDBRepository.php
@@ -33,14 +33,18 @@ class MongoDBRepository implements RepositoryInterface
     {
         $query   = $this->createQuery($criteria, $sagaId);
         $results = $query->execute();
-        $count   = count($results);
 
-        if ($count === 1) {
-            return State::deserialize(current($results->toArray()));
+        $ret = null;
+        foreach ($results as $result) {
+            if (null !== $ret) {
+                throw new RepositoryException('Multiple saga state instances found.');
+            }
+
+            $ret = $result;
         }
 
-        if ($count > 1) {
-            throw new RepositoryException('Multiple saga state instances found.');
+        if (null !== $ret) {
+            return State::deserialize($ret);
         }
 
         return null;


### PR DESCRIPTION
Inizialmente avevo parlato di questa modifica con @mriva per vedere se miglioravano le performance usando una query invece che due, ma avevo osservato che in realtà non cambiava praticamente niente

Ieri invece sono arrivato a guardare lo stesso codice con @ricfrank per un problema che arrivava dal canale pompiere (https://soisy.slack.com/archives/CL827SWBT/p1628859898004800) che, per quanto improbabile, abbiamo giustificato con un problema di concorrenza collegato al fatto che vengono fatte due query.

Per evitare quindi che le due query (la count e l'effettivo recupero dei risultati) possano recuperare risulatati incongruenti, l'idea è quella di usare una query unica.

Ho fatto girare i test di questa repository e passano tutti, quindi a livello di funzionalità il comportamento dovrebbe essere analogo.

A livello di performance, mi aspetto che questa modifica non sia peggiorativa. Il metodo `findOneBy` dovrebbe venire usato quando ci si aspetta di ricevere un solo risultato, quindi è molto improbabile che recuperi grandi collezioni. Inoltre l'uso del `foreach` su un `Iterable` spero (non ne ho la certezza però) faccia in modo di caricare in memoria i risultati uno alla volta; per come è implementato adesso il metodo, vorrebbe dire che ne carichiamo al più due.